### PR TITLE
Make string literal long enough to show problem; add NUL check back to tokenize.c.

### DIFF
--- a/examples/nqueens.c
+++ b/examples/nqueens.c
@@ -50,7 +50,7 @@ int main() {
   int board[100];
   for (int i = 0; i < 100; i++)
     board[i] = 0;
-  printf("Starting N-queens example...");	
+  printf("Memory safety example: Starting N-queens example...");
   solve(board, 0);
   return 0;
 }

--- a/tokenize.c
+++ b/tokenize.c
@@ -183,6 +183,8 @@ static Token *read_string_literal(Token *cur, char *start) {
   int len = 0;
 
   for (;;) {
+    if (*p == '\0')
+      error_at(start, "unclosed string literal");
     if (*p == '"')
       break;
 


### PR DESCRIPTION
The string literal needs to be > 32 characters; and the \0 check is an example for how the code can be fixed.